### PR TITLE
支持兼容IE浏览器

### DIFF
--- a/static/js/keyword.js
+++ b/static/js/keyword.js
@@ -28,7 +28,28 @@ $(function () {
   $searchLogo.on('click', function () {
     $searchMethods.show();
   });
+/*兼容处理 低版本IE*/
+//
+Array.prototype.find || (Array.prototype.find = function (predicate) {
+    if (this == null) {
+      throw new TypeError('Array.prototype.find called on null or undefined');
+    }
+    if (typeof predicate !== 'function') {
+      throw new TypeError('predicate must be a function');
+    }
+    var list = Object(this);
+    var length = list.length || 0;
+    var thisArg = arguments[1];
+    var value;
 
+    for (var i = 0; i < length; i++) {
+      value = list[i];
+      if (predicate.call(thisArg, value, i, list)) {
+        return value;
+      }
+    }
+    return null;
+})
   // 搜索引擎切换
   $searchMethods.on('click', 'li', function () {
     var type = $(this).data('type');


### PR DESCRIPTION
支持兼容IE浏览器；修改前的版本在IE浏览器上，搜索按钮会无效，通过调试发现IE浏览器对象不支持find属性方法，然后通过构造find方法进行补充。现在已经改好并通过了windows7和windows11系统上的IE11浏览器的测试。
麻烦大佬通过一下。